### PR TITLE
Update README.md to suggest dependencies = TRUE on install.packages() call

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Installation
 You can install repurrrsive from CRAN like so:
 
 ``` r
-install.packages("repurrrsive")
+install.packages("repurrrsive", dependencies = TRUE)
 ```
 
 or from GitHub with:


### PR DESCRIPTION
In the current readme file, it states to 
`install.packages("repurrrsive")`

However, this fails to load the example lists (e.g. wesanderson, got_chars, etc.).  If you install using:
`install.packages("repurrrsive", dependencies = TRUE)`
then those examples are made available within R.  

Note:  this is my first contribution to someone else's GIT repository.  I hope it proves more helpful than me just raising the issue I encountered.  Feel free to advise me on how to be more helpful.