### PR TITLE
Standardize Posit name

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Authors@R: c(
     person("Jennifer", "Bryan", , "jenny@rstudio.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-6983-2759")),
     person("Charlotte", "Wickham", , "cwickham@gmail.com", role = "ctb"),
-    person("Posit PBC", role = c("cph", "fnd"))
+    person("Posit Software, PBC", role = c("cph", "fnd"))
   )
 Description: Recursive lists in the form of R objects, 'JSON', and 'XML',
     for use in teaching and examples. Examples include color palettes,


### PR DESCRIPTION
I scraped CRAN to find companies that fund R packages, and noticed that Posit is credited 6 different ways (9 if you include RStudio/RStudio PBC/RStudio, PBC). I'm submitting PRs with the official "Posit Software, PBC" name on the few Posit varieties to nip it in the bud.